### PR TITLE
fix: accuracy logging

### DIFF
--- a/model/kogpt2.py
+++ b/model/kogpt2.py
@@ -111,7 +111,7 @@ class SubtaskGPT2(Classification):
         train_acc = self.metric_acc(torch.nn.functional.softmax(y_hat, dim=1),
                                     label)
         self.log("train_loss", train_loss, on_epoch=True, prog_bar=True)
-        self.log("train_acc", train_acc.compute(), on_step=True, prog_bar=True)
+        self.log("train_acc", train_acc, on_step=True, prog_bar=True)
         return train_loss
 
     def validation_step(self, batch, batch_idx):
@@ -130,10 +130,7 @@ class SubtaskGPT2(Classification):
     def validation_epoch_end(self, outputs):
         avg_loss = torch.stack([x["loss"] for x in outputs]).mean()
         self.log('val_loss', avg_loss)
-        self.log('val_acc',
-                 self.metric_acc_val.compute(),
-                 on_epoch=True,
-                 prog_bar=True)
+        self.log('val_acc', self.metric_acc_val, on_epoch=True, prog_bar=True)
 
 
 class SubtaskGPT2Regression(Classification):


### PR DESCRIPTION
## Description
문제점:
- compute() 시 자동으로 reset을 하지 않음

해결방안:

- 1안) self.log 통해서 자동 reset 
- 2안) compute()를 사용하면 reset()을 해야함

> the .reset() method of the metric will automatically be called at the end of an epoch within lightning only if you pass the metric instance inside self.log. Also if you are calling .compute by yourself, you need to call the .reset() too.

https://torchmetrics.readthedocs.io/en/latest/pages/lightning.html

p.s) 그 외 확인법: 에폭마다

```python
print(self.metric_acc_val.tp)
```
